### PR TITLE
Remove -y --force-yes from mysql-server installation

### DIFF
--- a/bin/preinstall
+++ b/bin/preinstall
@@ -22,7 +22,7 @@ install_mysql_server() {
 mysql-server-5.5 mysql-server/root_password password ${MYSQL_ROOT_PASSWORD}
 mysql-server-5.5 mysql-server/root_password_again password ${MYSQL_ROOT_PASSWORD}
 CONFIG
-				apt-get install mysql-server -y --force-yes
+				apt-get install mysql-server
 				load_tzinfo_to_mysql "${MYSQL_ROOT_PASSWORD}"
 			fi
 			;;

--- a/bin/preinstall
+++ b/bin/preinstall
@@ -22,7 +22,7 @@ install_mysql_server() {
 mysql-server-5.5 mysql-server/root_password password ${MYSQL_ROOT_PASSWORD}
 mysql-server-5.5 mysql-server/root_password_again password ${MYSQL_ROOT_PASSWORD}
 CONFIG
-				apt-get install mysql-server
+				apt-get install mysql-server -y
 				load_tzinfo_to_mysql "${MYSQL_ROOT_PASSWORD}"
 			fi
 			;;


### PR DESCRIPTION
If users have an existing database (either a custom mysql package, or a mariadb installation), this line will remove it silently, without warning. We discussed this before and it has now happened not with a custom mysql installation, but with a MariaDB server.

https://community.openproject.com/topics/9507?r=9507#message-9507